### PR TITLE
Py dep checks and paramiko

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -4,11 +4,24 @@
   become: no
   gather_facts: yes
   tasks:
-    - name: Make sure we are running correct Ansible Version
+
+    - name: Check installed python Modules
+      python_requirements_facts:
+        dependencies:
+          - boto
+          - netaddr
+          - passlib
+          - boto3>=1.7
+          - paramiko
+          - ansible>=2.8
+      register: py_dep
+
+    - name: Verify python dependencies are Installed
       assert:
         that:
-          - ansible_version.major >= 2
-          - ansible_version.minor >= 8
+          - py_dep.not_found |length==0
+          - py_dep.mismatched |length==0
+        msg: "Python dependencies not installed or at required version"
 
     - name: Make sure workshop_type is set to a correct value
       assert:

--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: grab boto version
-  command: "{{ansible_python['executable']}} -c 'import boto3; print(boto3.__version__)'"
-  register: py_cmd
-
-- name: make sure we are running correct boto version
-  assert:
-    that:
-      - py_cmd.stdout is version('1.7', operator='ge')
-    msg: "boto3 >= 1.7 is required."
-
 - name: check for underscores in workshop name
   fail:
     msg: "Amazon AWS does not allow underscores _ for s3 websites, please see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"


### PR DESCRIPTION
Py dep check and paramiko validation (python_requirements_facts is being used instead of info for backwards compatibility with 2.8)